### PR TITLE
Refactor docking tabs and add unpin support

### DIFF
--- a/src/dock_manager.c
+++ b/src/dock_manager.c
@@ -161,15 +161,6 @@ void DockManager_AddContent(DockManager* pMgr, DockContent* pContent, DockPane* 
     // TODO: Handle different DockPositions (splitting, etc.)
     // For now, only DOCK_POSITION_TABBED is implicitly handled by adding to pane's list.
 
-    // Update tab control if it exists
-    if (pTargetPane->hTabControl) {
-        TCITEM tcItem = { 0 };
-        tcItem.mask = TCIF_TEXT;
-        tcItem.pszText = pContent->title;
-        TabCtrl_InsertItem(pTargetPane->hTabControl, TabCtrl_GetItemCount(pTargetPane->hTabControl), &tcItem);
-        TabCtrl_SetCurSel(pTargetPane->hTabControl, pTargetPane->activeContentIndex);
-    }
-
     ShowWindow(pContent->hWnd, SW_SHOW); // Ensure child window is visible
     UpdateWindow(pContent->hWnd);
 }
@@ -184,7 +175,10 @@ DockPane* DockPane_Create(PaneType type, DockGroup* parentGroup) {
 
     pPane->type = type;
     pPane->contents = List_Create(sizeof(DockContent*)); // Initialize contents list
-    if (!pPane->contents) {
+    pPane->tabRects = List_Create(sizeof(RECT));
+    if (!pPane->contents || !pPane->tabRects) {
+        if (pPane->contents) List_Destroy(pPane->contents);
+        if (pPane->tabRects) List_Destroy(pPane->tabRects);
         free(pPane);
         return NULL;
     }
@@ -193,7 +187,7 @@ DockPane* DockPane_Create(PaneType type, DockGroup* parentGroup) {
     pPane->showTabs = TRUE; // Default
     pPane->showCaption = FALSE; // Default, caption might show if it's the only thing in a group or floating
 
-    // hTabControl would be created when the pane is actually displayed and needs tabs.
+    // tabRects will be computed during layout when tabs are shown.
     // rect will be set by layout logic.
 
     return pPane;
@@ -431,21 +425,6 @@ BOOL DockManager_RemoveContent(DockManager* pMgr, DockContent* pContentToRemove,
             parentPane->activeContentIndex = -1;
         }
 
-        if (parentPane->hTabControl) { // Refresh tab control
-            TabCtrl_DeleteAllItems(parentPane->hTabControl);
-            for (size_t i = 0; i < List_GetCount(parentPane->contents); ++i) {
-                DockContent* dc = *(DockContent**)List_GetAt(parentPane->contents, i);
-                TCITEMW tcItem = {0};
-                tcItem.mask = TCIF_TEXT | TCIF_PARAM;
-                tcItem.pszText = dc->title;
-                tcItem.lParam = (LPARAM)dc;
-                TabCtrl_InsertItem(parentPane->hTabControl, i, &tcItem);
-            }
-            if (parentPane->activeContentIndex != -1) {
-                TabCtrl_SetCurSel(parentPane->hTabControl, parentPane->activeContentIndex);
-            }
-        }
-
         // If pane becomes empty, remove it and collapse the group
         if (List_GetCount(parentPane->contents) == 0) {
             DockManager_RemovePane(pMgr, parentPane);
@@ -497,6 +476,31 @@ BOOL DockManager_RemoveContent(DockManager* pMgr, DockContent* pContentToRemove,
     return TRUE;
 }
 
+DockContent* DockManager_FindContentByHwnd(DockManager* pMgr, HWND hWnd) {
+    if (!pMgr || !hWnd) return NULL;
+
+    // Check main site
+    if (pMgr->mainDockSite) {
+        for (size_t i = 0; i < List_GetCount(pMgr->mainDockSite->allContents); ++i) {
+            DockContent* dc = *(DockContent**)List_GetAt(pMgr->mainDockSite->allContents, i);
+            if (dc && dc->hWnd == hWnd) return dc;
+        }
+    }
+
+    // Check floating windows
+    for (size_t i = 0; i < List_GetCount(pMgr->floatingWindows); ++i) {
+        FloatingWindow* fw = *(FloatingWindow**)List_GetAt(pMgr->floatingWindows, i);
+        if (fw && fw->dockSite) {
+            for (size_t j = 0; j < List_GetCount(fw->dockSite->allContents); ++j) {
+                DockContent* dc = *(DockContent**)List_GetAt(fw->dockSite->allContents, j);
+                if (dc && dc->hWnd == hWnd) return dc;
+            }
+        }
+    }
+
+    return NULL;
+}
+
 
 BOOL DockManager_UndockContent(DockManager* pMgr, DockContent* pContent) {
     if (!pMgr || !pContent || pContent->state != CONTENT_STATE_DOCKED || !pContent->parentPane) {
@@ -509,24 +513,10 @@ BOOL DockManager_UndockContent(DockManager* pMgr, DockContent* pContent) {
     List_RemovePointer(oldPane->contents, pContent);
     pContent->parentPane = NULL;
 
-    // Refresh original pane's tab control
-    if (oldPane->hTabControl) {
-        TabCtrl_DeleteAllItems(oldPane->hTabControl);
-        for (size_t i = 0; i < List_GetCount(oldPane->contents); ++i) {
-            DockContent* dc = *(DockContent**)List_GetAt(oldPane->contents, i);
-            TCITEMW tcItem = { 0 };
-            tcItem.mask = TCIF_TEXT | TCIF_PARAM;
-            tcItem.pszText = dc->title;
-            tcItem.lParam = (LPARAM)dc;
-            TabCtrl_InsertItem(oldPane->hTabControl, i, &tcItem);
-        }
-        if (List_GetCount(oldPane->contents) > 0) {
-            oldPane->activeContentIndex = 0; // Default to first tab
-            TabCtrl_SetCurSel(oldPane->hTabControl, oldPane->activeContentIndex);
-        } else {
-            oldPane->activeContentIndex = -1;
-            // TODO: If pane is empty, it might need to be removed/collapsed.
-        }
+    if (List_GetCount(oldPane->contents) > 0) {
+        oldPane->activeContentIndex = 0;
+    } else {
+        oldPane->activeContentIndex = -1;
     }
 
     if (siteOfOldPane) {
@@ -1061,56 +1051,56 @@ DockDropTarget DockManager_HitTest(DockManager* pMgr, POINT screenPt)
 {
 	DockDropTarget target = { 0 }; // Initialize to DOCK_DROP_AREA_NONE
 
-	// Check floating windows first, as they are on top
-	for (size_t i = 0; i < List_GetCount(pMgr->floatingWindows); ++i) {
-		FloatingWindow* pFltWnd = (FloatingWindow*)List_GetAt(pMgr->floatingWindows, i);
-		if (pFltWnd->dockSite) {
-			for (size_t j = 0; j < List_GetCount(pFltWnd->dockSite->allPanes); ++j) {
-				DockPane* pane = *(DockPane**)List_GetAt(pFltWnd->dockSite->allPanes, j);
-				if (pane->hTabControl && IsWindowVisible(pane->hTabControl)) {
-					RECT rcTab;
-					GetWindowRect(pane->hTabControl, &rcTab);
-					if (PtInRect(&rcTab, screenPt)) {
-						target.pane = pane;
-						target.area = DOCK_DROP_AREA_TAB_STRIP;
-						TCHITTESTINFO htInfo = { 0 };
-						htInfo.pt = screenPt;
-						ScreenToClient(pane->hTabControl, &htInfo.pt);
-						target.tabIndex = TabCtrl_HitTest(pane->hTabControl, &htInfo);
-						if (target.tabIndex == -1) {
-							target.tabIndex = TabCtrl_GetItemCount(pane->hTabControl);
-						}
-						// TODO: Calculate feedback rect for tab insertion
-						return target;
-					}
-				}
-			}
-		}
-	}
+        // Check floating windows first, as they are on top
+        for (size_t i = 0; i < List_GetCount(pMgr->floatingWindows); ++i) {
+                FloatingWindow* pFltWnd = (FloatingWindow*)List_GetAt(pMgr->floatingWindows, i);
+                if (pFltWnd->dockSite) {
+                        POINT ptClient = screenPt;
+                        ScreenToClient(pFltWnd->dockSite->hWnd, &ptClient);
+                        for (size_t j = 0; j < List_GetCount(pFltWnd->dockSite->allPanes); ++j) {
+                                DockPane* pane = *(DockPane**)List_GetAt(pFltWnd->dockSite->allPanes, j);
+                                RECT rcTabStrip = pane->rect;
+                                rcTabStrip.bottom = rcTabStrip.top + DEFAULT_TAB_HEIGHT;
+                                if (PtInRect(&rcTabStrip, ptClient)) {
+                                        target.pane = pane;
+                                        target.area = DOCK_DROP_AREA_TAB_STRIP;
+                                        target.tabIndex = List_GetCount(pane->contents);
+                                        for (size_t k = 0; k < List_GetCount(pane->tabRects); ++k) {
+                                                RECT r = *(RECT*)List_GetAt(pane->tabRects, k);
+                                                if (PtInRect(&r, ptClient)) {
+                                                        target.tabIndex = (int)k;
+                                                        break;
+                                                }
+                                        }
+                                        return target;
+                                }
+                        }
+                }
+        }
 
-	// Check main dock site
-	if (pMgr->mainDockSite) {
-		for (size_t i = 0; i < List_GetCount(pMgr->mainDockSite->allPanes); ++i) {
-			DockPane* pane = (DockPane*)List_GetAt(pMgr->mainDockSite->allPanes, i);
-			if (pane->hTabControl && IsWindowVisible(pane->hTabControl)) {
-				RECT rcTab;
-				GetWindowRect(pane->hTabControl, &rcTab);
-				if (PtInRect(&rcTab, screenPt)) {
-					target.pane = pane;
-					target.area = DOCK_DROP_AREA_TAB_STRIP;
-					TCHITTESTINFO htInfo = { 0 };
-					htInfo.pt = screenPt;
-					ScreenToClient(pane->hTabControl, &htInfo.pt);
-					target.tabIndex = TabCtrl_HitTest(pane->hTabControl, &htInfo);
-					if (target.tabIndex == -1) {
-						target.tabIndex = TabCtrl_GetItemCount(pane->hTabControl);
-					}
-					// TODO: Calculate feedback rect for tab insertion
-					return target;
-				}
-			}
-		}
-	}
+        // Check main dock site
+        if (pMgr->mainDockSite) {
+                POINT ptClient = screenPt;
+                ScreenToClient(pMgr->mainDockSite->hWnd, &ptClient);
+                for (size_t i = 0; i < List_GetCount(pMgr->mainDockSite->allPanes); ++i) {
+                        DockPane* pane = (DockPane*)List_GetAt(pMgr->mainDockSite->allPanes, i);
+                        RECT rcTabStrip = pane->rect;
+                        rcTabStrip.bottom = rcTabStrip.top + DEFAULT_TAB_HEIGHT;
+                        if (PtInRect(&rcTabStrip, ptClient)) {
+                                target.pane = pane;
+                                target.area = DOCK_DROP_AREA_TAB_STRIP;
+                                target.tabIndex = List_GetCount(pane->contents);
+                                for (size_t k = 0; k < List_GetCount(pane->tabRects); ++k) {
+                                        RECT r = *(RECT*)List_GetAt(pane->tabRects, k);
+                                        if (PtInRect(&r, ptClient)) {
+                                                target.tabIndex = (int)k;
+                                                break;
+                                        }
+                                }
+                                return target;
+                        }
+                }
+        }
 
 	// TODO: Add hit testing for center/side areas to allow splitting
 

--- a/src/dock_site.c
+++ b/src/dock_site.c
@@ -23,15 +23,13 @@ DockSite* DockSite_Create(HWND hWndOwner) {
 
 void DockPane_Destroy(DockPane* pPane) {
     if (!pPane) return;
-
-    if (pPane->hTabControl && IsWindow(pPane->hTabControl)) {
-        DestroyWindow(pPane->hTabControl);
-        pPane->hTabControl = NULL;
-    }
-
     if (pPane->contents) {
         List_Destroy(pPane->contents);
         pPane->contents = NULL;
+    }
+    if (pPane->tabRects) {
+        List_Destroy(pPane->tabRects);
+        pPane->tabRects = NULL;
     }
     free(pPane);
 }

--- a/src/dock_system.h
+++ b/src/dock_system.h
@@ -70,7 +70,7 @@ struct _DockPane {
     PaneType type;
     List* contents; // List of DockContent* items (tabs)
     int activeContentIndex;
-    HWND hTabControl; // HWND for the tab control UI, if applicable
+    List* tabRects;   // List of RECTs for manual tab hit-testing/drawing
 
     DockGroup* parentGroup; // Back-pointer
     RECT rect; // Current rectangle of this pane
@@ -168,6 +168,7 @@ void DockManager_Destroy(DockManager* pMgr);
 DockContent* DockManager_CreateContent(DockManager* pMgr, HWND hContentWnd, const wchar_t* title, const wchar_t* id, PaneType contentType);
 void DockManager_AddContent(DockManager* pMgr, DockContent* pContent, DockPane* pTargetPane /*optional*/, DockPosition position /*optional*/);
 BOOL DockManager_RemoveContent(DockManager* pMgr, DockContent* pContentToRemove, BOOL bDestroyContentHwnd); // This should also handle cleanup of empty panes/groups
+DockContent* DockManager_FindContentByHwnd(DockManager* pMgr, HWND hWnd);
 // ... other content functions
 
 // Layout and Operations

--- a/src/dock_test.c
+++ b/src/dock_test.c
@@ -180,8 +180,7 @@ void Test_PinMultipleWindows() {
     assert(List_GetCount(pMgr->mainDockSite->allContents) == 3);
 
     DockManager_LayoutDockSite(pMgr, pMgr->mainDockSite);
-    assert(targetPane->hTabControl != NULL); // Tab control should be created
-    assert(TabCtrl_GetItemCount(targetPane->hTabControl) == 3);
+    assert(List_GetCount(targetPane->tabRects) == 3);
 
     // Check visibility (conceptual - relies on UpdateContentWindowPositions logic)
     // For true check, would need GetWindowLong(hWnd, GWL_STYLE) & WS_VISIBLE
@@ -237,9 +236,8 @@ void Test_TabSelection() {
     DockManager_AddContent(pMgr, pContent2, targetPane, DOCK_POSITION_TABBED); // pContent2 is now active (index 1)
     assert(targetPane->activeContentIndex == 1);
 
-    // Simulate TCN_SELCHANGE by directly setting active index and re-layouting
+    // Simulate tab selection by directly setting active index and re-layouting
     targetPane->activeContentIndex = 0;
-    if(targetPane->hTabControl) TabCtrl_SetCurSel(targetPane->hTabControl, 0); // Also update visual tab
     DockManager_LayoutDockSite(pMgr, pMgr->mainDockSite);
     // In a real scenario with message loop, WM_NOTIFY would trigger this.
     // Here we test the consequence of activeContentIndex changing.

--- a/src/dockhost.c
+++ b/src/dockhost.c
@@ -267,7 +267,6 @@ void DockManager_LayoutPane(DockManager* pMgr, DockPane* pPane, RECT paneRect) {
     pPane->rect = paneRect;
 
     if (IsRectEmpty(&paneRect)) {
-        if(pPane->hTabControl) ShowWindow(pPane->hTabControl, SW_HIDE);
         if(pPane->contents) { // Hide all content windows if pane is empty
             for(size_t i = 0; i < List_GetCount(pPane->contents); ++i) {
                 DockContent* content = (DockContent*)List_GetAt(pPane->contents, i);
@@ -279,39 +278,25 @@ void DockManager_LayoutPane(DockManager* pMgr, DockPane* pPane, RECT paneRect) {
 
     BOOL tabsShouldBeVisible = pPane->showTabs && pPane->contents && List_GetCount(pPane->contents) > 0;
 
-    if (pPane->hTabControl) { // If tab control exists, position or hide it
-        if (tabsShouldBeVisible) {
-            RECT rcTabCtrl = paneRect; // Tab control takes the top part of the paneRect
-            rcTabCtrl.bottom = rcTabCtrl.top + DEFAULT_TAB_HEIGHT;
-            if (rcTabCtrl.bottom > paneRect.bottom) rcTabCtrl.bottom = paneRect.bottom; // Clamp to pane bottom
+    if (tabsShouldBeVisible) {
+        RECT rcTabStrip = paneRect;
+        rcTabStrip.bottom = rcTabStrip.top + DEFAULT_TAB_HEIGHT;
+        if (rcTabStrip.bottom > paneRect.bottom) rcTabStrip.bottom = paneRect.bottom;
 
-            SetWindowPos(pPane->hTabControl, NULL, rcTabCtrl.left, rcTabCtrl.top,
-                         rcTabCtrl.right - rcTabCtrl.left, rcTabCtrl.bottom - rcTabCtrl.top,
-                         SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
-        } else {
-            ShowWindow(pPane->hTabControl, SW_HIDE);
+        while (List_GetCount(pPane->tabRects) > 0) {
+            List_RemoveAt(pPane->tabRects, 0);
         }
-    } else if (tabsShouldBeVisible) {
-        pPane->hTabControl = CreateWindowEx(0, WC_TABCONTROLW, L"", // Use WC_TABCONTROLW for Unicode
-                                         WS_CHILD | WS_CLIPSIBLINGS | WS_VISIBLE | TCS_FOCUSNEVER | TCS_TOOLTIPS,
-                                         paneRect.left, paneRect.top, paneRect.right - paneRect.left, DEFAULT_TAB_HEIGHT,
-                                         pMgr->mainDockSite->hWnd,
-                                         (HMENU)(UINT_PTR)(pPane), // Using pane pointer as ID, ensure this is safe/unique enough
-                                         GetModuleHandle(NULL), NULL);
-        if (pPane->hTabControl) {
-            SendMessage(pPane->hTabControl, WM_SETFONT, (WPARAM)pMgr->uiFont, TRUE);
-            TabCtrl_DeleteAllItems(pPane->hTabControl); // Clear old tabs before repopulating
-            for (size_t i = 0; i < List_GetCount(pPane->contents); ++i) {
-                DockContent* dc = (DockContent*)List_GetAt(pPane->contents, i);
-                TCITEMW tcItem = { 0 };
-                tcItem.mask = TCIF_TEXT | TCIF_PARAM;
-                tcItem.pszText = dc->title;
-                tcItem.lParam = (LPARAM)dc;
-                TabCtrl_InsertItem(pPane->hTabControl, i, &tcItem);
-            }
-            if (pPane->activeContentIndex >=0 && pPane->activeContentIndex < (int)List_GetCount(pPane->contents)) {
-                 TabCtrl_SetCurSel(pPane->hTabControl, pPane->activeContentIndex);
-            }
+        int count = (int)List_GetCount(pPane->contents);
+        int tabWidth = (rcTabStrip.right - rcTabStrip.left) / (count > 0 ? count : 1);
+        int x = rcTabStrip.left;
+        for (int i = 0; i < count; ++i) {
+            RECT rc = { x, rcTabStrip.top, x + tabWidth, rcTabStrip.bottom };
+            List_Add(pPane->tabRects, &rc);
+            x += tabWidth;
+        }
+    } else if (pPane->tabRects) {
+        while (List_GetCount(pPane->tabRects) > 0) {
+            List_RemoveAt(pPane->tabRects, 0);
         }
     }
     // Actual content HWNDs are positioned in DockManager_UpdateContentWindowPositions
@@ -400,6 +385,25 @@ void DockPane_Paint(DockPane* pPane, HDC hdc, HBRUSH hCaptionBrush)
 
     // Draw border
     FrameRect(hdc, &pPane->rect, (HBRUSH)GetStockObject(DKGRAY_BRUSH));
+
+    // Draw tabs if any
+    if (pPane->showTabs && List_GetCount(pPane->contents) > 0) {
+        HFONT hOldFont = (HFONT)SelectObject(hdc, GetDockManager()->uiFont);
+        for (size_t i = 0; i < List_GetCount(pPane->contents); ++i) {
+            RECT rcTab = *(RECT*)List_GetAt(pPane->tabRects, i);
+            DockContent* dc = *(DockContent**)List_GetAt(pPane->contents, i);
+            HBRUSH hbr = (i == (size_t)pPane->activeContentIndex) ? (HBRUSH)GetStockObject(WHITE_BRUSH) : GetSysColorBrush(COLOR_BTNFACE);
+            FillRect(hdc, &rcTab, hbr);
+            FrameRect(hdc, &rcTab, (HBRUSH)GetStockObject(BLACK_BRUSH));
+            if (dc) {
+                RECT rcText = rcTab;
+                rcText.left += 4; rcText.right -= 4;
+                SetBkMode(hdc, TRANSPARENT);
+                DrawText(hdc, dc->title, -1, &rcText, DT_CENTER | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX);
+            }
+        }
+        SelectObject(hdc, hOldFont);
+    }
 
     // Draw caption if needed
     BOOL shouldShowCaption = pPane->showCaption || (pPane->showTabs && List_GetCount(pPane->contents) <= 1);
@@ -676,32 +680,36 @@ LRESULT DockHostWindow_UserProc(DockHostWindow* pDockHostWindow, HWND hWnd, UINT
             POINT ptDrop = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
             ClientToScreen(hWnd, &ptDrop);
 
-			DockDropArea dropArea = DockGuideManager_GetDropTarget(pDockHostWindow->dockGuideManager);
+                        DockDropArea dropArea = DockGuideManager_GetDropTarget(pDockHostWindow->dockGuideManager);
             DockDropTarget dropTarget = DockManager_HitTest(pMgr, ptDrop); // Also need the pane context
-			DockPane* sourcePane = pMgr->draggedTabPane;
-			int sourceIndex = pMgr->draggedTabIndexOriginal;
-			DockContent* contentToMove = *(DockContent**)List_GetAt(sourcePane->contents, sourceIndex);
+                        DockPane* sourcePane = pMgr->draggedTabPane;
+                        int sourceIndex = pMgr->draggedTabIndexOriginal;
+                        DockContent* contentToMove = *(DockContent**)List_GetAt(sourcePane->contents, sourceIndex);
 
-			if (contentToMove && dropArea != DOCK_DROP_AREA_NONE) {
+                        if (contentToMove && dropArea != DOCK_DROP_AREA_NONE) {
                 if (dropArea == DOCK_DROP_AREA_TAB_STRIP || dropArea == DOCK_DROP_AREA_CENTER)
                 {
-				    DockPane* destPane = dropTarget.pane;
-				    int destIndex = dropTarget.tabIndex;
+                                    DockPane* destPane = dropTarget.pane;
+                                    int destIndex = dropTarget.tabIndex;
 
-				// If dropping on the same pane, just reorder
-				if (sourcePane == destPane) {
-					if (sourceIndex != destIndex) {
-						List_RemoveAt(sourcePane->contents, sourceIndex);
-						if (destIndex > sourceIndex) destIndex--; // Adjust index after removal
-						if (destIndex < 0) destIndex = 0;
-						if (destIndex > (int)List_GetCount(sourcePane->contents)) destIndex = List_GetCount(sourcePane->contents);
-						List_InsertAt(sourcePane->contents, &contentToMove, destIndex);
-						sourcePane->activeContentIndex = destIndex; // Make dropped tab active
+                                // If dropping on the same pane, reorder or select
+                                if (sourcePane == destPane) {
+                                        if (sourceIndex != destIndex) {
+                                                List_RemoveAt(sourcePane->contents, sourceIndex);
+                                                if (destIndex > sourceIndex) destIndex--; // Adjust index after removal
+                                                if (destIndex < 0) destIndex = 0;
+                                                if (destIndex > (int)List_GetCount(sourcePane->contents)) destIndex = List_GetCount(sourcePane->contents);
+                                                List_InsertAt(sourcePane->contents, &contentToMove, destIndex);
+                                                sourcePane->activeContentIndex = destIndex; // Make dropped tab active
 
-						DockSite* site = GetSiteForPane(pMgr, sourcePane);
-						if (site) DockManager_LayoutDockSite(pMgr, site);
-					}
-				} else { // Dropping on a different pane
+                                                DockSite* site = GetSiteForPane(pMgr, sourcePane);
+                                                if (site) DockManager_LayoutDockSite(pMgr, site);
+                                        } else {
+                                                sourcePane->activeContentIndex = destIndex;
+                                                DockSite* site = GetSiteForPane(pMgr, sourcePane);
+                                                if (site) DockManager_LayoutDockSite(pMgr, site);
+                                        }
+                                } else { // Dropping on a different pane
 					DockSite* sourceSite = GetSiteForPane(pMgr, sourcePane);
 					DockSite* destSite = GetSiteForPane(pMgr, destPane);
 
@@ -736,17 +744,21 @@ LRESULT DockHostWindow_UserProc(DockHostWindow* pDockHostWindow, HWND hWnd, UINT
                     DockManager_RemoveContent(pMgr, contentToMove, FALSE);
                     // This is a simplified re-pin, a full implementation would be more complex
                     DockHostWindow_PinWindow(pDockHostWindow, contentToMove->hWnd, contentToMove->title, contentToMove->id, contentToMove->contentType, dropArea);
-                    if(sourceSite) DockManager_LayoutDockSite(pMgr, sourceSite);
+                                        if(sourceSite) DockManager_LayoutDockSite(pMgr, sourceSite);
                 }
 
-			} else if (contentToMove) { // Dropped somewhere else, float it
-				int dragThreshold = GetSystemMetrics(SM_CXDRAG) * 2;
-				if (abs(ptDrop.x - pMgr->ptTabDragStart.x) > dragThreshold ||
-					abs(ptDrop.y - pMgr->ptTabDragStart.y) > dragThreshold) {
-					RECT floatRect = { ptDrop.x - 150, ptDrop.y - 20, ptDrop.x + 150, ptDrop.y + 200 };
-					DockManager_FloatContent(pMgr, contentToMove, floatRect);
-				}
-			}
+                        } else if (contentToMove) { // Dropped somewhere else, float it or select
+                                int dragThreshold = GetSystemMetrics(SM_CXDRAG) * 2;
+                                if (abs(ptDrop.x - pMgr->ptTabDragStart.x) > dragThreshold ||
+                                        abs(ptDrop.y - pMgr->ptTabDragStart.y) > dragThreshold) {
+                                        RECT floatRect = { ptDrop.x - 150, ptDrop.y - 20, ptDrop.x + 150, ptDrop.y + 200 };
+                                        DockManager_FloatContent(pMgr, contentToMove, floatRect);
+                                } else {
+                                        sourcePane->activeContentIndex = sourceIndex;
+                                        DockSite* site = GetSiteForPane(pMgr, sourcePane);
+                                        if (site) DockManager_LayoutDockSite(pMgr, site);
+                                }
+                        }
 
             pMgr->isDraggingTab = FALSE;
             pMgr->draggedTabPane = NULL;
@@ -777,31 +789,9 @@ LRESULT DockHostWindow_UserProc(DockHostWindow* pDockHostWindow, HWND hWnd, UINT
         }
         break;
 
-    case WM_NOTIFY: // For tab control notifications
-        if (pDockHostWindow->dockSite && pDockHostWindow->dockSite->allPanes) {
-            LPNMHDR lpnmhdr = (LPNMHDR)lParam;
-            // Check if it's from one of our pane's tab controls
-            for(size_t i=0; i < List_GetCount(pDockHostWindow->dockSite->allPanes); ++i) {
-                DockPane* pane = *(DockPane**)List_GetAt(pDockHostWindow->dockSite->allPanes, i);
-                if (pane->hTabControl && pane->hTabControl == lpnmhdr->hwndFrom) {
-                    if (lpnmhdr->code == TCN_SELCHANGE) {
-                        int sel = TabCtrl_GetCurSel(pane->hTabControl);
-                        if (sel != -1 && sel < (int)List_GetCount(pane->contents)) {
-                            pane->activeContentIndex = sel;
-                            // DockContent* newActiveContent = (DockContent*)List_GetAt(pane->contents, sel);
-                            // TODO: Potentially bring newActiveContent's HWND to top among siblings if needed,
-                            // though ShowWindow/HideWindow in UpdateContentWindowPositions might be enough.
-                            DockManager_LayoutDockSite(pDockHostWindow->dockManager, pDockHostWindow->dockSite); // Re-layout to show/hide windows
-                        }
-                    }
-                    return 0; // Handled
-                }
-            }
         }
-        break;
-	}
 
-	return Window_UserProcDefault((Window *)pDockHostWindow, hWnd, message, wParam, lParam);
+        return Window_UserProcDefault((Window *)pDockHostWindow, hWnd, message, wParam, lParam);
 }
 
 void DockHostWindow_PreRegister(LPWNDCLASSEX lpwcex)
@@ -972,6 +962,25 @@ void DockHostWindow_PinWindow(DockHostWindow* pDockHostWindow, HWND hWndToPin, c
     DockManager_LayoutDockSite(pMgr, mainSite);
     // ShowWindow(hWndToPin, SW_SHOWNA); // Show without activating, LayoutDockSite will handle visibility
     // UpdateWindow(hWndToPin);
+}
+
+void DockHostWindow_UnpinWindow(DockHostWindow* pDockHostWindow, HWND hWndToUnpin) {
+    if (!pDockHostWindow || !pDockHostWindow->dockManager || !hWndToUnpin) {
+        return;
+    }
+
+    DockManager* pMgr = pDockHostWindow->dockManager;
+    DockContent* content = DockManager_FindContentByHwnd(pMgr, hWndToUnpin);
+    if (!content) {
+        return;
+    }
+
+    DockManager_RemoveContent(pMgr, content, FALSE);
+    SetParent(hWndToUnpin, NULL);
+    DWORD style = GetWindowLong(hWndToUnpin, GWL_STYLE);
+    style |= WS_OVERLAPPEDWINDOW;
+    SetWindowLong(hWndToUnpin, GWL_STYLE, style);
+    ShowWindow(hWndToUnpin, SW_SHOW);
 }
 
 

--- a/src/dockhost.h
+++ b/src/dockhost.h
@@ -40,6 +40,7 @@ struct _DockHostWindow {
 DockHostWindow* DockHostWindow_Create(PanitentApp* pApp); // pApp might be needed to get main HWND for DockManager
 
 void DockHostWindow_PinWindow(DockHostWindow* pDockHostWindow, HWND hWndToPin, const wchar_t* title, const wchar_t* id, PaneType contentType, DockPosition position);
+void DockHostWindow_UnpinWindow(DockHostWindow* pDockHostWindow, HWND hWndToUnpin);
 
 // Functions for creating nodes and data are now part of DockManager or helpers in dock_system.c
 // DockData* DockData_Create(int iGripPos, DWORD dwStyle, BOOL bShowCaption);


### PR DESCRIPTION
## Summary
- Draw and hit-test docked pane tabs manually instead of relying on Win32 tab controls
- Add ability to unpin docked panes back to standalone windows

## Testing
- `cmake --build .` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6895024bd7788333b44f2531fe36fe4b