### PR TITLE
Add scripts to convert Visual Studio solutions to CMake projects

### DIFF
--- a/scripts/convert_vs_to_cmake.ps1
+++ b/scripts/convert_vs_to_cmake.ps1
@@ -1,0 +1,35 @@
+param(
+    [Parameter(Mandatory=$true)][string]$Solution
+)
+
+$root = Split-Path $Solution -Parent
+$solName = [IO.Path]::GetFileNameWithoutExtension($Solution)
+$rootCmake = Join-Path $root 'CMakeLists.txt'
+
+@("cmake_minimum_required(VERSION 3.10)", "project($solName)", "") | Set-Content $rootCmake
+
+Get-Content $Solution | Where-Object { $_ -match '^Project\("' } | ForEach-Object {
+    $parts = $_ -split '"'
+    $name = $parts[3]
+    $path = $parts[5]
+    $projFile = Join-Path $root $path
+    if (-not (Test-Path $projFile)) { return }
+
+    $projDir = Split-Path $path
+    $configType = (Select-String -Path $projFile -Pattern '<ConfigurationType>([^<]+)</ConfigurationType>' -List | Select-Object -First 1).Matches[0].Groups[1].Value
+    $sources = Select-String -Path $projFile -Pattern '<ClCompile Include="([^"]+)' | ForEach-Object { $_.Matches[0].Groups[1].Value.Replace('\\','/') }
+
+    if ($configType -eq 'StaticLibrary') {
+        $libCmake = Join-Path $root $projDir 'CMakeLists.txt'
+        "add_library($name STATIC" | Set-Content $libCmake
+        $sources | ForEach-Object { "    $_" | Add-Content $libCmake }
+        ")" | Add-Content $libCmake
+        if ($projDir -ne '') { "add_subdirectory($projDir)" | Add-Content $rootCmake }
+    }
+    else {
+        if ($projDir -ne '') { $sources = $sources | ForEach-Object { "$projDir/$_" } }
+        "add_executable($name" | Add-Content $rootCmake
+        $sources | ForEach-Object { "    $_" | Add-Content $rootCmake }
+        ")" | Add-Content $rootCmake
+    }
+}

--- a/scripts/convert_vs_to_cmake.sh
+++ b/scripts/convert_vs_to_cmake.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Convert a Visual Studio solution (.sln) into a basic CMake project.
+# Usage: ./convert_vs_to_cmake.sh path/to/solution.sln
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <solution.sln>" >&2
+    exit 1
+fi
+
+sln="$1"
+root_dir=$(dirname "$sln")
+sol_name=$(basename "${sln%.sln}")
+root_cmake="$root_dir/CMakeLists.txt"
+
+{
+  echo "cmake_minimum_required(VERSION 3.10)"
+  echo "project($sol_name)"
+  echo
+} > "$root_cmake"
+
+while IFS= read -r line; do
+    proj_name=$(echo "$line" | cut -d '"' -f4)
+    proj_path=$(echo "$line" | cut -d '"' -f6)
+    proj_file="$root_dir/$proj_path"
+    [[ -f "$proj_file" ]] || continue
+
+    proj_dir=$(dirname "$proj_path")
+    config_type=$(grep -oP '(?<=<ConfigurationType>)[^<]+' "$proj_file" | head -n1)
+
+    mapfile -t sources < <(grep -oP '(?<=<ClCompile Include=")[^"]+' "$proj_file" | tr '\\' '/')
+
+    if [[ "$config_type" == "StaticLibrary" ]]; then
+        lib_cmake="$root_dir/$proj_dir/CMakeLists.txt"
+        {
+          echo "add_library(${proj_name} STATIC"
+          for src in "${sources[@]}"; do
+              echo "    ${src}"
+          done
+          echo ")"
+        } > "$lib_cmake"
+
+        [[ "$proj_dir" != "." ]] && echo "add_subdirectory($proj_dir)" >> "$root_cmake"
+    else
+        if [[ "$proj_dir" != "." ]]; then
+            for i in "${!sources[@]}"; do
+                sources[$i]="$proj_dir/${sources[$i]}"
+            done
+        fi
+        {
+          echo "add_executable(${proj_name}"
+          for src in "${sources[@]}"; do
+              echo "    ${src}"
+          done
+          echo ")"
+        } >> "$root_cmake"
+    fi
+done < <(grep '^Project(' "$sln")


### PR DESCRIPTION
## Summary
- add `convert_vs_to_cmake.sh` script to generate CMakeLists from .sln/.vcxproj
- add PowerShell `convert_vs_to_cmake.ps1` with equivalent functionality

## Testing
- `./scripts/convert_vs_to_cmake.sh $tmpdir/panitent.sln`
- `bash -n scripts/convert_vs_to_cmake.sh`
- `pwsh -NoLogo -File scripts/convert_vs_to_cmake.ps1 -Solution "$tmpdir/panitent.sln"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_6895092df78c8333a69bb3c16fb961ed